### PR TITLE
removed nbParticipants field

### DIFF
--- a/api/src/main/java/com/api/entities/Formation.java
+++ b/api/src/main/java/com/api/entities/Formation.java
@@ -19,7 +19,6 @@ public class Formation {
 
     private boolean isConfirmed;
     private int minParticipants;
-    private int nbParticipants;
     private boolean isPerso;
     private boolean isInterEntreprise;
     private String link;


### PR DESCRIPTION
Removed `nbParticipants` field from the `Formation` class as this value is easily accessible from `stagiaireList` field with the `size()` method.