### PR TITLE
Add user class and role to contact responsable

### DIFF
--- a/api/src/main/java/com/api/controllers/UserController.java
+++ b/api/src/main/java/com/api/controllers/UserController.java
@@ -1,0 +1,31 @@
+package com.api.controllers;
+
+import com.api.dto.UserDTO;
+import com.api.entities.User;
+import com.api.helpers.MappingHelper;
+import com.api.repositories.UserRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "http://localhost:4200")
+@RestController
+@RequestMapping("/user-controller")
+public class UserController implements MappingHelper<UserDTO, User> {
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @PostMapping("/createUser")
+    public boolean createResponsable(@RequestBody UserDTO userDTO) {
+        userRepo.save(unMapDTO(userDTO, User.class));
+        return true;
+    }
+
+
+    @GetMapping("/getResponsableMail")
+    public String getResponsableMail() {
+        return userRepo.findByRole("responsable").getMail();
+    }
+
+
+}

--- a/api/src/main/java/com/api/controllers/UserController.java
+++ b/api/src/main/java/com/api/controllers/UserController.java
@@ -5,6 +5,7 @@ import com.api.entities.User;
 import com.api.helpers.MappingHelper;
 import com.api.repositories.UserRepo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @CrossOrigin(origins = "http://localhost:4200")
@@ -21,10 +22,16 @@ public class UserController implements MappingHelper<UserDTO, User> {
         return true;
     }
 
+    @GetMapping("/getById/{id}")
+    public ResponseEntity<UserDTO> getUserById(@PathVariable int id) {
+        User user = userRepo.findById(id).orElseThrow(() -> new RuntimeException("No such User with id " + id));
+        return ResponseEntity.ok(mapToDTO(user, UserDTO.class));
+    }
 
     @GetMapping("/getResponsableMail")
     public String getResponsableMail() {
-        return userRepo.findByRole("responsable").getMail();
+        User user = userRepo.findByRole("responsable").orElseThrow(() -> new RuntimeException("No such User with role = responsable"));
+        return user.getMail();
     }
 
 

--- a/api/src/main/java/com/api/dto/UserDTO.java
+++ b/api/src/main/java/com/api/dto/UserDTO.java
@@ -1,0 +1,22 @@
+package com.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+
+    private Integer id;
+    private String name;
+    private String mail;
+    private String role;
+
+    public UserDTO(String name, String mail, String role) {
+        this.name = name;
+        this.mail = mail;
+        this.role = role;
+    }
+}

--- a/api/src/main/java/com/api/entities/User.java
+++ b/api/src/main/java/com/api/entities/User.java
@@ -1,0 +1,22 @@
+package com.api.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "user")
+public class User {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "id_user")
+    private Integer id;
+
+    private String name;
+    private String mail;
+    private String login;
+    private String password;
+    private String role;
+
+}

--- a/api/src/main/java/com/api/repositories/UserRepo.java
+++ b/api/src/main/java/com/api/repositories/UserRepo.java
@@ -3,8 +3,11 @@ package com.api.repositories;
 import com.api.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepo extends JpaRepository<User, Integer> {
 
-    User findByRole(String role);
+    Optional<User> findById(int id);
+    Optional<User> findByRole(String role);
 
 }

--- a/api/src/main/java/com/api/repositories/UserRepo.java
+++ b/api/src/main/java/com/api/repositories/UserRepo.java
@@ -1,0 +1,10 @@
+package com.api.repositories;
+
+import com.api.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepo extends JpaRepository<User, Integer> {
+
+    User findByRole(String role);
+
+}


### PR DESCRIPTION
This PR introduces a new class `User` which has different fields highly useful for login and role handling. To do so, a `Repository` interface, `Controller` and `DTO` classes have also been created. The controller can retrieve an instance of `User` from the database by its `id` or even just get the `mail` of the Responsable by a single query, and finaly create and add a `User` to the database.