### PR TITLE
Remove application properties from git

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -2,8 +2,6 @@ HELP.md
 target/
 !.mvn/wrapper/maven-wrapper.jar
 
-application.properties
-
 ### Java ###
 .class
 

--- a/api/src/main/resources/.gitignore
+++ b/api/src/main/resources/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+!README.md

--- a/api/src/main/resources/README.md
+++ b/api/src/main/resources/README.md
@@ -1,0 +1,1 @@
+## This folder *MUST* be kept as it contains the `application.properties` file.

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,8 +1,0 @@
-#server.port=8080
-spring.datasource.url=jdbc:mysql://localhost/fil_rouge
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
-spring.datasource.username=root
-spring.datasource.password=root


### PR DESCRIPTION
This PR is another take at PR #47 and should allow keep the `application.properties` file only without removing the `resources` folder.